### PR TITLE
fix broken pipe if compile fails (for use with `gulp-plumber`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = function () {
 			data = imba.compile(file.contents.toString());
 		} catch (err) {
 			this.emit('error', new PluginError(NAME, err, {fileName: file.path}));
+			return;
 		}
 
 		// make .js file


### PR DESCRIPTION
When using `gulp.watch` the pipe was breaking even when using `gulp-plumber`, this seems to fix it.

```
  gulp.src(paths.src.imba)
  .pipe(plumber())
  .pipe(imba())
  .pipe(gulp.dest(paths.build.imba))
```
