### PR TITLE
fix rebuilding after compilation fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = function () {
 			data = imba.compile(file.contents.toString());
 		} catch (err) {
 			this.emit('error', new PluginError(NAME, err, {fileName: file.path}));
+			cb(err);
 			return;
 		}
 


### PR DESCRIPTION
Whoops. Looks like whilst the last fix did stop the pipe from breaking, it prevented subsequent rebuilds.

This fixes that behaviour.

Apologies!
